### PR TITLE
Use 239 as DumpedPrivateKeyHeader for TestNetParams

### DIFF
--- a/core/src/main/java/io/xpydev/paycoinj/core/DownloadListener.java
+++ b/core/src/main/java/io/xpydev/paycoinj/core/DownloadListener.java
@@ -61,7 +61,7 @@ public class DownloadListener extends AbstractPeerEventListener {
             done.release();
         }
 
-        if (blocksLeft < 0 || originalBlocksLeft <= 0)
+        if (blocksLeft <= 0 || originalBlocksLeft <= 0)
             return;
 
         double pct = 100.0 - (100.0 * (blocksLeft / (double) originalBlocksLeft));

--- a/core/src/main/java/io/xpydev/paycoinj/params/TestNetParams.java
+++ b/core/src/main/java/io/xpydev/paycoinj/params/TestNetParams.java
@@ -31,7 +31,7 @@ public class TestNetParams extends NetworkParameters {
         interval = INTERVAL;
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = Utils.decodeCompactBits(0x200fffffL);
-        dumpedPrivateKeyHeader = 183;
+        dumpedPrivateKeyHeader = 239;
         addressHeader = 111;
         p2shHeader = 196;
         acceptableAddressCodes = new int[] { addressHeader, p2shHeader };


### PR DESCRIPTION
ingcr3at1on spotted an incompatibility with importing private keys from
the Qt testnet wallet -- it was due to the incorrect private key header
Also fixed an issue with the DownloadListener not considering blocksLeft
== 0 as complete
