### PR TITLE
Use daemon threads on FullPrunedBlockChain

### DIFF
--- a/core/src/main/java/io/xpydev/paycoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/io/xpydev/paycoinj/core/FullPrunedBlockChain.java
@@ -21,6 +21,7 @@ import io.xpydev.paycoinj.script.Script;
 import io.xpydev.paycoinj.script.Script.VerifyFlag;
 import io.xpydev.paycoinj.store.BlockStoreException;
 import io.xpydev.paycoinj.store.FullPrunedBlockStore;
+import io.xpydev.paycoinj.utils.DaemonThreadFactory;
 import io.xpydev.paycoinj.store.ValidHashStore;
 
 import org.slf4j.Logger;
@@ -123,7 +124,8 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
     //TODO: Remove lots of duplicated code in the two connectTransactions
 
     // TODO: execute in order of largest transaction (by input count) first
-    ExecutorService scriptVerificationExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+    ExecutorService scriptVerificationExecutor = Executors.newFixedThreadPool(
+            Runtime.getRuntime().availableProcessors(), new DaemonThreadFactory());
 
     /** A job submitted to the executor which verifies signatures. */
     private static class Verifier implements Callable<VerificationException> {

--- a/core/src/main/java/io/xpydev/paycoinj/net/discovery/DnsDiscovery.java
+++ b/core/src/main/java/io/xpydev/paycoinj/net/discovery/DnsDiscovery.java
@@ -19,6 +19,7 @@ package io.xpydev.paycoinj.net.discovery;
 
 import io.xpydev.paycoinj.core.NetworkParameters;
 import com.google.common.collect.Lists;
+import io.xpydev.paycoinj.utils.DaemonThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +72,7 @@ public class DnsDiscovery implements PeerDiscovery {
 
         // Java doesn't have an async DNS API so we have to do all lookups in a thread pool, as sometimes seeds go
         // hard down and it takes ages to give up and move on.
-        ExecutorService threadPool = Executors.newFixedThreadPool(dnsSeeds.length);
+        ExecutorService threadPool = Executors.newFixedThreadPool(dnsSeeds.length, new DaemonThreadFactory());
         try {
             List<Callable<InetAddress[]>> tasks = Lists.newArrayList();
             for (final String seed : dnsSeeds) {
@@ -120,4 +121,3 @@ public class DnsDiscovery implements PeerDiscovery {
     }
 
 }
-

--- a/core/src/main/java/io/xpydev/paycoinj/net/discovery/TorDiscovery.java
+++ b/core/src/main/java/io/xpydev/paycoinj/net/discovery/TorDiscovery.java
@@ -34,6 +34,7 @@ import com.subgraph.orchid.circuits.path.CircuitPathChooser;
 import com.subgraph.orchid.data.HexDigest;
 import com.subgraph.orchid.data.exitpolicy.ExitTarget;
 
+import io.xpydev.paycoinj.utils.DaemonThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -252,8 +253,8 @@ public class TorDiscovery implements PeerDiscovery {
     }
 
     private synchronized void createThreadPool(int size) {
-        threadPool =
-                MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(size));
+        threadPool = MoreExecutors.listeningDecorator(
+                Executors.newFixedThreadPool(size, new DaemonThreadFactory()));
     }
 
     private InetAddress lookup(Circuit circuit, String seed) throws UnknownHostException {
@@ -293,4 +294,3 @@ public class TorDiscovery implements PeerDiscovery {
         }
     }
 }
-

--- a/core/src/main/java/io/xpydev/paycoinj/utils/DaemonThreadFactory.java
+++ b/core/src/main/java/io/xpydev/paycoinj/utils/DaemonThreadFactory.java
@@ -1,0 +1,16 @@
+package io.xpydev.paycoinj.utils;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+/** Thread factory whose threads are marked as daemon and won't prevent process exit. */
+public class DaemonThreadFactory implements ThreadFactory {
+
+    @Override
+    public Thread newThread(@Nonnull Runnable runnable) {
+        Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+        thread.setDaemon(true);
+        return thread;
+    }
+}


### PR DESCRIPTION
This way, the thread pool used to run the transaction scripts won’t prevent applications from exiting.

Reference: https://github.com/bitcoinj/bitcoinj/commit/42f9d7c193fcd56fda7691b0ea934bae9d23f2d6
