### PR TITLE
Exclude scrypt libs by default (Android doesn't like them)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -234,6 +234,9 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+										<exclude>lib/x86_64/darwin/libscrypt.dylib</exclude>
+										<exclude>lib/x86_64/freebsd/libscrypt.so</exclude>
+										<exclude>lib/x86_64/linux/libscrypt.so</exclude>                            
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
Splitting this from https://github.com/PaycoinFoundation/paycoinj/pull/16
