### PR TITLE
Expose methods for use

### DIFF
--- a/core/src/main/java/io/xpydev/paycoinj/core/Peer.java
+++ b/core/src/main/java/io/xpydev/paycoinj/core/Peer.java
@@ -1389,6 +1389,13 @@ public class Peer extends PeerSocketHandler {
                 throw new RuntimeException(e);
             }
         }
+        
+        if (blockLocator.size() > 1) {
+            // For some reason we lose the last block when switching peers:
+            // remove the head so that it gets replayed
+            blockLocator.remove(0);
+        }
+        
         // Only add the locator if we didn't already do so. If the chain is < 50 blocks we already reached it.
         if (cursor != null)
             blockLocator.add(params.getGenesisBlock().getHash());

--- a/core/src/main/java/io/xpydev/paycoinj/core/Wallet.java
+++ b/core/src/main/java/io/xpydev/paycoinj/core/Wallet.java
@@ -2041,7 +2041,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
      * If the transactions outputs are all marked as spent, and it's in the unspent map, move it.
      * If the owned transactions outputs are not all marked as spent, and it's in the spent map, move it.
      */
-    private void maybeMovePool(Transaction tx, String context) {
+    public void maybeMovePool(Transaction tx, String context) {
         checkState(lock.isHeldByCurrentThread());
         if (tx.isEveryOwnedOutputSpent(this)) {
             // There's nothing left I can spend in this transaction.


### PR DESCRIPTION
Exposed Wallet#maybeMovePool() for manually inserting txns
Remove head from from block locator to replay last block when switching
peers -- otherwise, some txns tend to get lost

Splitting this from https://github.com/PaycoinFoundation/paycoinj/pull/16
