### PR TITLE
Version 0.3.3 changes

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.xpydev</groupId>
         <artifactId>paycoinj-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.3.3</version>
     </parent>
 
     <artifactId>paycoinj</artifactId>
@@ -234,6 +234,9 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+										<exclude>lib/x86_64/darwin/libscrypt.dylib</exclude>
+										<exclude>lib/x86_64/freebsd/libscrypt.so</exclude>
+										<exclude>lib/x86_64/linux/libscrypt.so</exclude>                            
                                     </excludes>
                                 </filter>
                             </filters>

--- a/core/src/main/java/io/xpydev/paycoinj/core/AbstractWalletEventListener.java
+++ b/core/src/main/java/io/xpydev/paycoinj/core/AbstractWalletEventListener.java
@@ -54,6 +54,11 @@ public abstract class AbstractWalletEventListener extends AbstractKeyChainEventL
     public void onScriptsAdded(Wallet wallet, List<Script> scripts) {
         onChange();
     }
+    
+    @Override
+    public void onScriptsChanged(Wallet wallet, List<Script> scripts, boolean isAddingScripts) {
+        onChange();
+    }
 
     @Override
     public void onWalletChanged(Wallet wallet) {

--- a/core/src/main/java/io/xpydev/paycoinj/core/CheckpointManager.java
+++ b/core/src/main/java/io/xpydev/paycoinj/core/CheckpointManager.java
@@ -195,6 +195,10 @@ public class CheckpointManager {
         return checkpoints.size();
     }
 
+    public TreeMap<Long, StoredBlock> getCheckpoints() {
+        return checkpoints;
+    }
+    
     /** Returns a hash of the concatenated checkpoint data. */
     public Sha256Hash getDataHash() {
         return dataHash;

--- a/core/src/main/java/io/xpydev/paycoinj/core/DownloadProgressTracker.java
+++ b/core/src/main/java/io/xpydev/paycoinj/core/DownloadProgressTracker.java
@@ -1,0 +1,130 @@
+package io.xpydev.paycoinj.core;
+/**
+ * Copyright 2011 Google Inc.
+ * Copyright 2014 Andreas Schildbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Date;
+import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import io.xpydev.paycoinj.core.AbstractPeerEventListener;
+import io.xpydev.paycoinj.core.Block;
+import io.xpydev.paycoinj.core.Peer;
+import io.xpydev.paycoinj.core.Utils;
+
+/**
+ * <p>
+ * An implementation of {@link AbstractPeerEventListener} that listens to chain
+ * download events and tracks progress as a percentage. The default
+ * implementation prints progress to stdout, but you can subclass it and
+ * override the progress method to update a GUI instead.
+ * </p>
+ */
+public class DownloadProgressTracker extends AbstractPeerEventListener {
+    private static final Logger log = LoggerFactory.getLogger(DownloadProgressTracker.class);
+    private int originalBlocksLeft = -1;
+    private int lastPercent = 0;
+    private SettableFuture<Long> future = SettableFuture.create();
+    private boolean caughtUp = false;
+
+    @Override
+    public void onChainDownloadStarted(Peer peer, int blocksLeft) {
+        if (blocksLeft > 0 && originalBlocksLeft == -1) startDownload(blocksLeft);
+        // Only mark this the first time, because this method can be called more
+        // than once during a chain download
+        // if we switch peers during it.
+        if (originalBlocksLeft == -1) originalBlocksLeft = blocksLeft;
+        else log.info("Chain download switched to {}", peer);
+        if (blocksLeft <= 0) {
+            caughtUp = true;
+            doneDownload();
+            future.set(peer.getBestHeight());
+        }
+    }
+
+    @Override
+    public void onBlocksDownloaded(Peer peer, Block block, int blocksLeft) {
+        if (caughtUp) return;
+
+        if (blocksLeft <= 0) {
+            caughtUp = true;
+            doneDownload();
+            future.set(peer.getBestHeight());
+        }
+
+        if (blocksLeft <= 0 || originalBlocksLeft <= 0) return;
+
+        double pct = 100.0 - (100.0 * (blocksLeft / (double) originalBlocksLeft));
+        if ((int) pct != lastPercent) {
+            progress(pct, blocksLeft, new Date(block.getTimeSeconds() * 1000));
+            lastPercent = (int) pct;
+        }
+    }
+
+    /**
+     * Called when download progress is made.
+     *
+     * @param pct
+     *            the percentage of chain downloaded, estimated
+     * @param date
+     *            the date of the last block downloaded
+     */
+    protected void progress(double pct, int blocksSoFar, Date date) {
+        log.info(String.format("Chain download %d%% done with %d blocks to go, block date %s", (int) pct, blocksSoFar,
+                Utils.dateTimeFormat(date)));
+    }
+
+    /**
+     * Called when download is initiated.
+     *
+     * @param blocks
+     *            the number of blocks to download, estimated
+     */
+    protected void startDownload(int blocks) {
+        log.info("Downloading block chain of size " + blocks + ". " +
+                (blocks > 1000 ? "This may take a while." : ""));
+    }
+
+    /**
+     * Called when we are done downloading the block chain.
+     */
+    protected void doneDownload() {
+    }
+
+    /**
+     * Wait for the chain to be downloaded.
+     */
+    public void await() throws InterruptedException {
+        try {
+            future.get();
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Returns a listenable future that completes with the height of the best
+     * chain (as reported by the peer) once chain download seems to be finished.
+     */
+    public ListenableFuture<Long> getFuture() {
+        return future;
+    }
+}

--- a/core/src/main/java/io/xpydev/paycoinj/core/NetworkParameters.java
+++ b/core/src/main/java/io/xpydev/paycoinj/core/NetworkParameters.java
@@ -42,10 +42,12 @@ import static io.xpydev.paycoinj.core.Coin.*;
  * them, you are encouraged to call the static get() methods on each specific params class directly.</p>
  */
 public abstract class NetworkParameters implements Serializable {
+    private static final long serialVersionUID = 516551887248710642L;
+
     /**
      * The protocol version this library implements.
      */
-    public static final int PROTOCOL_VERSION = 70003;
+    public static final int PROTOCOL_VERSION = 70006;
 
     /**
      * The alert signing key.

--- a/core/src/main/java/io/xpydev/paycoinj/core/Peer.java
+++ b/core/src/main/java/io/xpydev/paycoinj/core/Peer.java
@@ -300,7 +300,7 @@ public class Peer extends PeerSocketHandler {
 
     @Override
     public void connectionOpened() {
-        // Announce ourselves. This has to come first to connect to clients beyond v0.3.20.2 which wait to hear
+        // Announce ourselves. This has to come first to connect to clients beyond v0.3.3 which wait to hear
         // from us until they send their version message back.
         PeerAddress address = getAddress();
         log.info("Announcing to {} as: {}", address == null ? "Peer" : address.toSocketAddress(), versionMessage.subVer);
@@ -1228,6 +1228,7 @@ public class Peer extends PeerSocketHandler {
      */
     public void setDownloadParameters(long secondsSinceEpoch, boolean useFilteredBlocks) {
     	// For peercoin we cannot use filtered blocks until the protocol has been upgraded
+        useFilteredBlocks = false;
         lock.lock();
         try {
             Preconditions.checkNotNull(blockChain);
@@ -1389,6 +1390,13 @@ public class Peer extends PeerSocketHandler {
                 throw new RuntimeException(e);
             }
         }
+        
+        if (blockLocator.size() > 1) {
+            // For some reason we lose the last block when switching peers:
+            // remove the head so that it gets replayed
+            blockLocator.remove(0);
+        }
+        
         // Only add the locator if we didn't already do so. If the chain is < 50 blocks we already reached it.
         if (cursor != null)
             blockLocator.add(params.getGenesisBlock().getHash());

--- a/core/src/main/java/io/xpydev/paycoinj/core/PeerGroup.java
+++ b/core/src/main/java/io/xpydev/paycoinj/core/PeerGroup.java
@@ -121,7 +121,7 @@ public class PeerGroup extends AbstractExecutionThreadService implements Transac
     // until we reach this count.
     @GuardedBy("lock") private int maxConnections;
     // Minimum protocol version we will allow ourselves to connect to: Do not require bloom filtering as it doesn't exist in Paycoin
-    private volatile int vMinRequiredProtocolVersion = 70003;
+    private volatile int vMinRequiredProtocolVersion = 70006;
 
     // Runs a background thread that we use for scheduling pings to our peers, so we can measure their performance
     // and network latency. We ping peers every pingIntervalMsec milliseconds.
@@ -202,6 +202,10 @@ public class PeerGroup extends AbstractExecutionThreadService implements Transac
             queueRecalc(false);
         }
 
+        @Override public void onScriptsChanged(Wallet wallet, java.util.List<Script> scripts, boolean isAddingScripts) {
+            queueRecalc(false);
+        }
+        
         @Override public void onKeysAdded(List<ECKey> keys) {
             queueRecalc(false);
         }

--- a/core/src/main/java/io/xpydev/paycoinj/core/VersionMessage.java
+++ b/core/src/main/java/io/xpydev/paycoinj/core/VersionMessage.java
@@ -77,7 +77,7 @@ public class VersionMessage extends Message {
     public boolean relayTxesBeforeFilter;
 
     /** The version of this library release, as a string. */
-    public static final String PAYCOINJ_VERSION = "0.1.0";
+    public static final String PAYCOINJ_VERSION = "0.3.3";
     /** The value that is prepended to the subVer field of this application. */
     public static final String LIBRARY_SUBVER = "/paycoinJ:" + PAYCOINJ_VERSION + "/";
 

--- a/core/src/main/java/io/xpydev/paycoinj/core/WalletEventListener.java
+++ b/core/src/main/java/io/xpydev/paycoinj/core/WalletEventListener.java
@@ -119,4 +119,10 @@ public interface WalletEventListener extends KeyChainEventListener {
     /** Called whenever a new watched script is added to the wallet. */
     void onScriptsAdded(Wallet wallet, List<Script> scripts);
 
+    /**
+     * Called whenever a new watched script is added to the wallet.
+     *
+     * @param isAddingScripts will be true if added scripts, false if removed scripts.
+     */
+    void onScriptsChanged(Wallet wallet, List<Script> scripts, boolean isAddingScripts);
 }

--- a/core/src/main/java/io/xpydev/paycoinj/jni/NativeWalletEventListener.java
+++ b/core/src/main/java/io/xpydev/paycoinj/jni/NativeWalletEventListener.java
@@ -54,4 +54,7 @@ public class NativeWalletEventListener implements WalletEventListener {
 
     @Override
     public native void onScriptsAdded(Wallet wallet, List<Script> scripts);
+    
+    @Override
+    public native void onScriptsChanged(Wallet wallet, List<Script> scripts, boolean isAddingScripts);
 }

--- a/core/src/main/java/io/xpydev/paycoinj/params/MainNetParams.java
+++ b/core/src/main/java/io/xpydev/paycoinj/params/MainNetParams.java
@@ -26,6 +26,7 @@ import static com.google.common.base.Preconditions.checkState;
  * Parameters for the main production network on which people trade goods and services.
  */
 public class MainNetParams extends NetworkParameters {
+    private static final long serialVersionUID = 1994314767223570084L;
     public MainNetParams() {
         super();
         interval = INTERVAL;
@@ -91,7 +92,7 @@ public class MainNetParams extends NetworkParameters {
 
         dnsSeeds = new String[] {
                 "dnsseed.paycoin.com"
-//              , "dnsseed.paycoinfoundation.org"
+              , "dnsseed.paycoinfoundation.org"
               , "dnsseed.xpydev.org"
         };
 

--- a/core/src/main/java/io/xpydev/paycoinj/script/ScriptOpCodes.java
+++ b/core/src/main/java/io/xpydev/paycoinj/script/ScriptOpCodes.java
@@ -161,6 +161,7 @@ public class ScriptOpCodes {
     public static final int OP_PRIMENODE20 = 0xc3;
     public static final int OP_PRIMENODE10 = 0xc4;
     public static final int OP_PRIMENODEP2 = 0xc5;
+    public static final int OP_MICROPRIME = 0xc6;
     
     // template matching params
     public static final int OP_SMALLINTEGER = 0xfa;
@@ -285,6 +286,7 @@ public class ScriptOpCodes {
         .put(OP_PRIMENODE20, "PRIMENODE20")
         .put(OP_PRIMENODE10, "PRIMENODE10")
         .put(OP_PRIMENODEP2, "PRIMENODEP2")
+        .put(OP_MICROPRIME, "OP_MICROPRIME")
         .put(OP_SMALLINTEGER, "SMALLINTEGER")
         .put(OP_PUBKEYS, "PUBKEYS")
         .put(OP_PUBKEYHASH, "PUBKEYHASH")
@@ -407,6 +409,7 @@ public class ScriptOpCodes {
         .put("PRIMENODE20", OP_PRIMENODE20)
         .put("PRIMENODE10", OP_PRIMENODE10)
         .put("PRIMENODEP2", OP_PRIMENODEP2)
+        .put("OP_MICROPRIME", OP_MICROPRIME)
         .put("SMALLINTEGER", OP_SMALLINTEGER)
         .put("PUBKEYS", OP_PUBKEYS)
         .put("PUBKEYHASH", OP_PUBKEYHASH)

--- a/core/src/main/java/io/xpydev/paycoinj/utils/Threading.java
+++ b/core/src/main/java/io/xpydev/paycoinj/utils/Threading.java
@@ -116,8 +116,8 @@ public class Threading {
         public void execute(Runnable command) {
             if (tasks.size() > 100) {
                 log.warn("User thread saturated, memory exhaustion may occur.");
-                log.warn("Check for deadlocked or slow event handlers. Sample tasks:");
-                for (Object task : tasks.toArray()) log.warn(task.toString());
+                log.warn("Check for deadlocked or slow event handlers. Sample tasks: {}", tasks);
+                // for (Object task : tasks.toArray()) log.warn(task.toString());
             }
             Uninterruptibles.putUninterruptibly(tasks, command);
         }

--- a/orchid/pom.xml
+++ b/orchid/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.xpydev</groupId>
         <artifactId>paycoinj-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.3.3</version>
     </parent>
 
     <artifactId>orchid</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.xpydev</groupId>
   <artifactId>paycoinj-parent</artifactId>
-  <version>0.1.0</version>
+  <version>0.3.3</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
Modified PROTOCOL_VERSION to 70003 (0.3.3)
Trigger #onChange from #onScriptsChanged() from AbstractWalletListener
(e.g., notifications for multisig addresses)
Added reusable DownloadProgressTracker (base implementation for
AbstractPeerEventListener)
Expose #checkpoints from CheckpointManager
Force #useFilteredBlocks to false from #setDownloadParameters (since
paycoinj does not support bloom filtering)
Fixed issue with missing txns from the last block when switching peers
Added support for removing watched addresses from the wallet
Added support for watching multisig addresses
Added OP_MICROPRIME code
